### PR TITLE
allows concourse default variable expansion

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -41,8 +41,14 @@ if [ -z "$options" ]; then
   exit 1
 fi
 
+expanded_options=$(sed "s/\$BUILD_ID/$BUILD_ID/g" <<<$options)
+expanded_options=$(sed "s/\$BUILD_TEAM_NAME/$BUILD_TEAM_NAME/g" <<<$expanded_options)
+expanded_options=$(sed "s/\$BUILD_JOB_NAME/$BUILD_JOB_NAME/g" <<<$expanded_options)
+expanded_options=$(sed "s/\$BUILD_NAME/$BUILD_NAME/g" <<<$expanded_options)
+expanded_options=$(sed "s/\$ATC_EXTERNAL_URL/$ATC_EXTERNAL_URL/g" <<<$expanded_options)
+
 if [ "$secure_output" = false ]; then
-  echo "Options: $options"
+  echo "Options: $expanded_options"
 else
   echo "Options: ##SUPRESSED##"
 fi
@@ -64,7 +70,7 @@ while read $READSWITCH line; do
     fi
     fly -t main $line
   )
-done <<< "$options"
+done <<< "$expanded_options"
 
 jq -n "{
   version: {}


### PR DESCRIPTION
Some shell variables are injected by concourse, it is now possible to using them in fly command.